### PR TITLE
SwiftGenerators: Add DSL for FOXInteger()

### DIFF
--- a/Fox/Public/Generators/SwiftGenerators.swift
+++ b/Fox/Public/Generators/SwiftGenerators.swift
@@ -85,6 +85,10 @@ public func boolean() -> FOXGenerator {
     return FOXBoolean()
 }
 
+public func integer() -> FOXGenerator {
+    return FOXInteger()
+}
+
 public func positiveInteger() -> FOXGenerator {
     return FOXPositiveInteger()
 }


### PR DESCRIPTION
So, so awesome of you to include Swift DSL. And thanks to namespacing, no prefixes!! :+1: :100: 

This adds a DSL for `FOXInteger()`.
