### PR TITLE
DSL.swift: Use random seed by default

### DIFF
--- a/Fox/Public/DSL.swift
+++ b/Fox/Public/DSL.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public func Assert(
     property: FOXGenerator,
-    seed: UInt32?,
+    seed: UInt32? = nil,
     numberOfTests: UInt = FOXDefaultNumberOfTests,
     maximumSize: UInt = FOXDefaultMaximumSize,
     file: String = __FILE__,


### PR DESCRIPTION
Providing a default value for the seed parameter allows consumers to
leave it out altogether, i.e.:

``` swift
Assert(forAll(FOXInteger(), { integer in
  let weight = integer as Int
  let banana = Banana(weight: weight)
  let peeled = peel(banana)
  return peeled.weight == banana.weight
})) // <- No need to specify `seed: nil` as 2nd param to `Assert` here.
```
