### PR TITLE
Fix build for Carthage

### DIFF
--- a/Fox.xcodeproj/project.pbxproj
+++ b/Fox.xcodeproj/project.pbxproj
@@ -1376,6 +1376,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -1407,6 +1408,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",

--- a/Fox/Public/Random/FOXDeterministicRandom.mm
+++ b/Fox/Public/Random/FOXDeterministicRandom.mm
@@ -38,9 +38,9 @@
 
 - (long long)randomIntegerWithinMinimum:(long long)minimumNumber andMaximum:(long long)maximumNumber
 {
-    NSInteger difference = maximumNumber - minimumNumber;
-    std::uniform_int_distribution<NSInteger> distributionRange(0, difference);
-    NSInteger randomNumber = distributionRange(_generator);
+    long long difference = maximumNumber - minimumNumber;
+    std::uniform_int_distribution<long long> distributionRange(0, difference);
+    long long randomNumber = distributionRange(_generator);
     return randomNumber + minimumNumber;
 }
 

--- a/FoxSpecs/Helpers/FOXSpecHelper.m
+++ b/FoxSpecs/Helpers/FOXSpecHelper.m
@@ -11,7 +11,7 @@
 
 + (void)initialize
 {
-    printf("FOX_NUM_TESTS=%lu, FOX_SEED=%lu, FOX_MAX_SIZE=%lu\n", FOXGetNumberOfTests(), FOXGetSeed(), FOXGetMaximumSize());
+    printf("FOX_NUM_TESTS=%lu, FOX_SEED=%lu, FOX_MAX_SIZE=%lu\n", (unsigned long)FOXGetNumberOfTests(), (unsigned long)FOXGetSeed(), (unsigned long)FOXGetMaximumSize());
 }
 
 + (FOXRunnerResult *)resultForAll:(id<FOXGenerator>)generator

--- a/FoxSpecs/Public/Generators/FOXFloatSpec.mm
+++ b/FoxSpecs/Public/Generators/FOXFloatSpec.mm
@@ -25,7 +25,7 @@ describe(@"FOXFloat", ^{
     });
 
     it(@"should generate NaN", ^{
-        FOXRunnerResult *result = [FOXSpecHelper resultForAll:FOXResize(FOXFloat(), UINT64_MAX) then:^BOOL(NSNumber *generatedValue) {
+        FOXRunnerResult *result = [FOXSpecHelper resultForAll:FOXResize(FOXFloat(), NSUIntegerMax) then:^BOOL(NSNumber *generatedValue) {
             return !isnan([generatedValue floatValue]);
         } numberOfTests:10000];
         result.succeeded should be_falsy;

--- a/FoxSpecs/Public/Random/FOXRandomSpec.mm
+++ b/FoxSpecs/Public/Random/FOXRandomSpec.mm
@@ -13,7 +13,7 @@ describe(@"FOXDeterministicRandom", ^{
             FOXDeterministicRandom *random1 = [[FOXDeterministicRandom alloc] initWithSeed:(uint32_t)[value integerValue]];
             FOXDeterministicRandom *random2 = [[FOXDeterministicRandom alloc] initWithSeed:(uint32_t)[value integerValue]];
             BOOL equalRandInts = [random1 randomInteger] == [random2 randomInteger];
-            NSUInteger actual = [random1 randomIntegerWithinMinimum:5 andMaximum:1000];
+            long long actual = [random1 randomIntegerWithinMinimum:5 andMaximum:1000];
             return equalRandInts && (actual == [random2 randomIntegerWithinMinimum:5 andMaximum:1000]);
         }];
         result should be_truthy;
@@ -24,7 +24,7 @@ describe(@"FOXDeterministicRandom", ^{
             FOXDeterministicRandom *random1 = [[FOXDeterministicRandom alloc] init];
             FOXDeterministicRandom *random2 = [[FOXDeterministicRandom alloc] init];
             BOOL equalRandInts = [random1 randomInteger] != [random2 randomInteger];
-            NSUInteger actual = [random1 randomIntegerWithinMinimum:5 andMaximum:1000];
+            long long actual = [random1 randomIntegerWithinMinimum:5 andMaximum:1000];
             return equalRandInts || (actual != [random2 randomIntegerWithinMinimum:5 andMaximum:1000]);
         }];
         result should be_truthy;


### PR DESCRIPTION
This adds [Carthage](https://github.com/Carthage/Carthage) support, ensuring that `carthage build --no-skip-current` works on Fox.

The primary issue here was that compiling for _device_ introduces several 64-bit to 32-bit conversions. Since the warning for that is explicitly enabled, I fixed up the conversions themselves rather than disabling it.

Resolves #8.

/cc @jeffh @modocache 