### PR TITLE
Added famous value generators for numeric types

### DIFF
--- a/Fox.xcodeproj/project.pbxproj
+++ b/Fox.xcodeproj/project.pbxproj
@@ -260,6 +260,10 @@
 		1FFCE5681A80B90700A427AA /* FOXLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FFCE5651A80B90700A427AA /* FOXLimits.h */; };
 		1FFCE5691A80B90700A427AA /* FOXLimits.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FFCE5661A80B90700A427AA /* FOXLimits.mm */; };
 		1FFCE56A1A80B90700A427AA /* FOXLimits.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FFCE5661A80B90700A427AA /* FOXLimits.mm */; };
+		1FFCE56C1A81DF8300A427AA /* FOXStrictPositiveIntegerSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FFCE56B1A81DF8300A427AA /* FOXStrictPositiveIntegerSpec.mm */; };
+		1FFCE56D1A81DF8300A427AA /* FOXStrictPositiveIntegerSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FFCE56B1A81DF8300A427AA /* FOXStrictPositiveIntegerSpec.mm */; };
+		1FFCE56F1A81E13400A427AA /* FOXStrictNegativeIntegerSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FFCE56E1A81E13400A427AA /* FOXStrictNegativeIntegerSpec.mm */; };
+		1FFCE5701A81E13400A427AA /* FOXStrictNegativeIntegerSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FFCE56E1A81E13400A427AA /* FOXStrictNegativeIntegerSpec.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -383,6 +387,8 @@
 		1FF6737D1A2AC7E200F98D20 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		1FFCE5651A80B90700A427AA /* FOXLimits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FOXLimits.h; path = Fox/Private/FOXLimits.h; sourceTree = SOURCE_ROOT; };
 		1FFCE5661A80B90700A427AA /* FOXLimits.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = FOXLimits.mm; path = Fox/Private/FOXLimits.mm; sourceTree = SOURCE_ROOT; };
+		1FFCE56B1A81DF8300A427AA /* FOXStrictPositiveIntegerSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = FOXStrictPositiveIntegerSpec.mm; path = FoxSpecs/Public/Generators/FOXStrictPositiveIntegerSpec.mm; sourceTree = SOURCE_ROOT; };
+		1FFCE56E1A81E13400A427AA /* FOXStrictNegativeIntegerSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = FOXStrictNegativeIntegerSpec.mm; path = FoxSpecs/Public/Generators/FOXStrictNegativeIntegerSpec.mm; sourceTree = SOURCE_ROOT; };
 		31B730183A626AD19A2B366E /* FOXSequence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FOXSequence.h; sourceTree = "<group>"; };
 		31B73029745CB5B325095CB3 /* QueueAddTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QueueAddTransition.m; sourceTree = "<group>"; };
 		31B7303EEEA0827C94541FB4 /* FOXStateMachine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FOXStateMachine.h; sourceTree = "<group>"; };
@@ -683,6 +689,8 @@
 				1F8FDC021989FED70059D31A /* FOXStringSpec.mm */,
 				1FA94A35199606F800803AF3 /* FOXSuchThatSpec.mm */,
 				1F35BC2D198DB6AA00BEA6E1 /* FOXTupleGeneratorSpec.mm */,
+				1FFCE56B1A81DF8300A427AA /* FOXStrictPositiveIntegerSpec.mm */,
+				1FFCE56E1A81E13400A427AA /* FOXStrictNegativeIntegerSpec.mm */,
 			);
 			path = Generators;
 			sourceTree = "<group>";
@@ -1083,6 +1091,7 @@
 				1F38B6D71A2ACCF10078FF90 /* FOXRandomSpec.mm in Sources */,
 				1F38B6CD1A2ACCDF0078FF90 /* NSArray+FastEnumerator.m in Sources */,
 				1F71D4FA1A3143A70017E81A /* FOXResizeSpec.mm in Sources */,
+				1FFCE56F1A81E13400A427AA /* FOXStrictNegativeIntegerSpec.mm in Sources */,
 				1F38B6D91A2ACCF10078FF90 /* FOXRoseTreeSpec.mm in Sources */,
 				1F38B6E61A2ACCF10078FF90 /* FOXSuchThatSpec.mm in Sources */,
 				1F38B6E51A2ACCF10078FF90 /* FOXFiniteStateMachineSpec.mm in Sources */,
@@ -1102,6 +1111,7 @@
 				1F38B6E11A2ACCF10078FF90 /* FOXSetSpec.mm in Sources */,
 				1F38B6DB1A2ACCF10078FF90 /* FOXChooseSpec.mm in Sources */,
 				1F38B6D41A2ACCE80078FF90 /* QueueAddTransition.m in Sources */,
+				1FFCE56C1A81DF8300A427AA /* FOXStrictPositiveIntegerSpec.mm in Sources */,
 				1F38B6DF1A2ACCF10078FF90 /* FOXPositiveIntegerSpec.mm in Sources */,
 				1F38B6D61A2ACCE80078FF90 /* FOXSpecHelper.m in Sources */,
 				1F38B6DC1A2ACCF10078FF90 /* FOXDictionarySpec.mm in Sources */,
@@ -1172,6 +1182,7 @@
 				1F38B6E91A2ACCF20078FF90 /* FOXRandomSpec.mm in Sources */,
 				1F38B6CE1A2ACCE00078FF90 /* NSArray+FastEnumerator.m in Sources */,
 				1F71D4FB1A3143A70017E81A /* FOXResizeSpec.mm in Sources */,
+				1FFCE5701A81E13400A427AA /* FOXStrictNegativeIntegerSpec.mm in Sources */,
 				1F38B6EB1A2ACCF20078FF90 /* FOXRoseTreeSpec.mm in Sources */,
 				1F38B6F81A2ACCF20078FF90 /* FOXSuchThatSpec.mm in Sources */,
 				1F38B6F71A2ACCF20078FF90 /* FOXFiniteStateMachineSpec.mm in Sources */,
@@ -1191,6 +1202,7 @@
 				1F38B6F31A2ACCF20078FF90 /* FOXSetSpec.mm in Sources */,
 				1F38B6ED1A2ACCF20078FF90 /* FOXChooseSpec.mm in Sources */,
 				1F38B6D01A2ACCE70078FF90 /* QueueAddTransition.m in Sources */,
+				1FFCE56D1A81DF8300A427AA /* FOXStrictPositiveIntegerSpec.mm in Sources */,
 				1F38B6F11A2ACCF20078FF90 /* FOXPositiveIntegerSpec.mm in Sources */,
 				1F38B6D21A2ACCE70078FF90 /* FOXSpecHelper.m in Sources */,
 				1F38B6EE1A2ACCF20078FF90 /* FOXDictionarySpec.mm in Sources */,

--- a/Fox.xcodeproj/project.pbxproj
+++ b/Fox.xcodeproj/project.pbxproj
@@ -256,6 +256,10 @@
 		1FAE3B6F1A2F10080011838A /* FOXFloatSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FAE3B6D1A2F10080011838A /* FOXFloatSpec.mm */; };
 		1FC42D481A34E8E8006455F2 /* FOXBindSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FC42D471A34E8E8006455F2 /* FOXBindSpec.mm */; };
 		1FC42D491A34E8E8006455F2 /* FOXBindSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FC42D471A34E8E8006455F2 /* FOXBindSpec.mm */; };
+		1FFCE5671A80B90700A427AA /* FOXLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FFCE5651A80B90700A427AA /* FOXLimits.h */; };
+		1FFCE5681A80B90700A427AA /* FOXLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FFCE5651A80B90700A427AA /* FOXLimits.h */; };
+		1FFCE5691A80B90700A427AA /* FOXLimits.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FFCE5661A80B90700A427AA /* FOXLimits.mm */; };
+		1FFCE56A1A80B90700A427AA /* FOXLimits.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FFCE5661A80B90700A427AA /* FOXLimits.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -377,6 +381,8 @@
 		1FF5B93C1973BD9000416383 /* FOXRoseTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FOXRoseTree.h; sourceTree = "<group>"; };
 		1FF5B93D1973BD9000416383 /* FOXRoseTree.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FOXRoseTree.m; sourceTree = "<group>"; };
 		1FF6737D1A2AC7E200F98D20 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		1FFCE5651A80B90700A427AA /* FOXLimits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FOXLimits.h; path = Fox/Private/FOXLimits.h; sourceTree = SOURCE_ROOT; };
+		1FFCE5661A80B90700A427AA /* FOXLimits.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = FOXLimits.mm; path = Fox/Private/FOXLimits.mm; sourceTree = SOURCE_ROOT; };
 		31B730183A626AD19A2B366E /* FOXSequence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FOXSequence.h; sourceTree = "<group>"; };
 		31B73029745CB5B325095CB3 /* QueueAddTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QueueAddTransition.m; sourceTree = "<group>"; };
 		31B7303EEEA0827C94541FB4 /* FOXStateMachine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FOXStateMachine.h; sourceTree = "<group>"; };
@@ -693,6 +699,8 @@
 		1F8FDBE6198776FA0059D31A /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				1FFCE5651A80B90700A427AA /* FOXLimits.h */,
+				1FFCE5661A80B90700A427AA /* FOXLimits.mm */,
 				1F46E505198CAE6400F87028 /* Generators */,
 				1F8FDBE7198777080059D31A /* Data */,
 			);
@@ -800,6 +808,7 @@
 				1F38B6551A2ACCAE0078FF90 /* FOXArray.h in Headers */,
 				1F38B6211A2ACCA80078FF90 /* FOXChooseGenerator.h in Headers */,
 				1F38B6C31A2ACCC00078FF90 /* FOXDeterministicRandom.h in Headers */,
+				1FFCE5671A80B90700A427AA /* FOXLimits.h in Headers */,
 				1F38B6A01A2ACCC00078FF90 /* FOXRunnerResult.h in Headers */,
 				1F38B6B91A2ACCC00078FF90 /* FOXStringGenerators.h in Headers */,
 			);
@@ -855,6 +864,7 @@
 				1F38B6611A2ACCAE0078FF90 /* FOXArray.h in Headers */,
 				1F38B6391A2ACCA90078FF90 /* FOXChooseGenerator.h in Headers */,
 				1F38B68E1A2ACCC00078FF90 /* FOXDeterministicRandom.h in Headers */,
+				1FFCE5681A80B90700A427AA /* FOXLimits.h in Headers */,
 				1F38B66B1A2ACCC00078FF90 /* FOXRunnerResult.h in Headers */,
 				1F38B6841A2ACCC00078FF90 /* FOXStringGenerators.h in Headers */,
 			);
@@ -1049,6 +1059,7 @@
 				1F38B6241A2ACCA80078FF90 /* FOXMapGenerator.m in Sources */,
 				1F38B62E1A2ACCA80078FF90 /* FOXStringGenerator.m in Sources */,
 				1F38B6B71A2ACCC00078FF90 /* FOXStateMachineGenerators.m in Sources */,
+				1FFCE5691A80B90700A427AA /* FOXLimits.mm in Sources */,
 				1F38B6BC1A2ACCC00078FF90 /* FOXGenericGenerators.m in Sources */,
 				1FAE3B681A2EC5E60011838A /* SwiftGenerators.swift in Sources */,
 				1F38B6201A2ACCA80078FF90 /* FOXBindGenerator.m in Sources */,
@@ -1137,6 +1148,7 @@
 				1F38B63C1A2ACCA90078FF90 /* FOXMapGenerator.m in Sources */,
 				1F38B6461A2ACCA90078FF90 /* FOXStringGenerator.m in Sources */,
 				1F38B6821A2ACCC00078FF90 /* FOXStateMachineGenerators.m in Sources */,
+				1FFCE56A1A80B90700A427AA /* FOXLimits.mm in Sources */,
 				1F38B6871A2ACCC00078FF90 /* FOXGenericGenerators.m in Sources */,
 				1FAE3B691A2EC5E60011838A /* SwiftGenerators.swift in Sources */,
 				1F38B6381A2ACCA90078FF90 /* FOXBindGenerator.m in Sources */,

--- a/Fox/Private/FOXLimits.h
+++ b/Fox/Private/FOXLimits.h
@@ -1,0 +1,11 @@
+#import "FOXMacros.h"
+
+// use -MAX to get lowest value
+
+FOX_EXPORT float FOXFloatMax(void);
+FOX_EXPORT float FOXFloatInfinity(void);
+FOX_EXPORT float FOXFloatQNaN(void);
+
+FOX_EXPORT double FOXDoubleInfinity(void);
+FOX_EXPORT double FOXDoubleMax(void);
+FOX_EXPORT double FOXDoubleQNaN(void);

--- a/Fox/Private/FOXLimits.mm
+++ b/Fox/Private/FOXLimits.mm
@@ -1,0 +1,26 @@
+#import "FOXLimits.h"
+#include <limits>
+
+FOX_EXPORT float FOXFloatMax(void) {
+    return std::numeric_limits<float>::max();
+}
+
+FOX_EXPORT float FOXFloatInfinity(void) {
+    return std::numeric_limits<float>::infinity();
+}
+
+FOX_EXPORT float FOXFloatQNaN(void) {
+    return std::numeric_limits<float>::quiet_NaN();
+}
+
+FOX_EXPORT double FOXDoubleMax(void) {
+    return std::numeric_limits<double>::max();
+}
+
+FOX_EXPORT double FOXDoubleInfinity(void) {
+    return std::numeric_limits<double>::infinity();
+}
+
+FOX_EXPORT double FOXDoubleQNaN(void) {
+    return std::numeric_limits<double>::quiet_NaN();
+}

--- a/Fox/Public/Generators/FOXNumericGenerators.h
+++ b/Fox/Public/Generators/FOXNumericGenerators.h
@@ -185,14 +185,36 @@ FOX_EXPORT id<FOXGenerator> FOXFamousStrictPositiveInteger(void);
 FOX_EXPORT id<FOXGenerator> FOXFamousNonZeroInteger(void);
 
 /*! Creates a generator that produces random floats (boxed as NSNumbers) with
- *  an increased probability of choosing extreme values (NAN, INFINITY,
- *  -INFINITY, -0). Shrinks towards zero. Floats generated conform to
+ *  an increased probability of choosing extreme values (NaN, INFINITY,
+ *  -INFINITY, -0, MAX, MIN). Shrinks towards zero. Doubles generated conform to
  *  IEEE standard.
  *
- *  The size hint dictates the min & max values that can be generated.
+ *  The size hint dictates the min & max values that can be generated with the
+ *  exception of extreme values.
  *
  *  @returns a generator that produces floats (boxed in NSNumbers).
  */
 FOX_EXPORT id<FOXGenerator> FOXFamousFloat(void);
+
+/*! Creates a generator that produces random doubles (boxed as NSNumbers) with
+ *  an increased probability of choosing extreme values (NaN, INFINITY,
+ *  -INFINITY, -0, MIN, MAX). Shrinks towards zero. Doubles generated conform to
+ *  IEEE standard.
+ *
+ *  The size hint dictates the min & max values that can be generated with the
+ *  exception of extreme values.
+ *
+ *  @returns a generator that produces doubles (boxed in NSNumbers).
+ */
 FOX_EXPORT id<FOXGenerator> FOXFamousDouble(void);
+
+/*! Creates a generator that produces random decimal numbers with an increased
+ *  probability of choosing extreme values (NaN, MIN, MAX).
+ *  Shrinks towards [NSDecimalNumber zero].
+ *
+ *  The size hint dictates the min & max values that can be generated with the
+ *  exception of extreme values.
+ *
+ *  @returns a generator that produces NSDecimalNumbers.
+ */
 FOX_EXPORT id<FOXGenerator> FOXFamousDecimalNumber(void);

--- a/Fox/Public/Generators/FOXNumericGenerators.h
+++ b/Fox/Public/Generators/FOXNumericGenerators.h
@@ -16,6 +16,7 @@ FOX_EXPORT id<FOXGenerator> FOXBoolean(void);
  *
  *  The size hint dictates the min & max integer values that can be generated.
  *
+ *  @seealso FOXFamousInteger
  *  @returns a generator that produces integers (boxed in NSNumbers).
  */
 FOX_EXPORT id<FOXGenerator> FOXInteger(void);
@@ -26,6 +27,7 @@ FOX_EXPORT id<FOXGenerator> FOXInteger(void);
  *  The size hint dictates the min & max integer values that can be generated,
  *  bounding to 0 as the minimum.
  *
+ *  @seealso FOXFamousPositiveInteger
  *  @returns a generator that produces integers (boxed in NSNumbers).
  */
 FOX_EXPORT id<FOXGenerator> FOXPositiveInteger(void);
@@ -36,6 +38,7 @@ FOX_EXPORT id<FOXGenerator> FOXPositiveInteger(void);
  *  The size hint dictates the min & max integer values that can be generated,
  *  bounding to 1 as the minimum.
  *
+ *  @seealso FOXFamousStrictPositiveInteger
  *  @returns a generator that produces integers (boxed in NSNumbers).
  */
 FOX_EXPORT id<FOXGenerator> FOXStrictPositiveInteger(void);
@@ -46,6 +49,7 @@ FOX_EXPORT id<FOXGenerator> FOXStrictPositiveInteger(void);
  *  The size hint dictates the min & max integer values that can be generated,
  *  bounding to 0 as the maximum.
  *
+ *  @seealso FOXFamousNegativeInteger
  *  @returns a generator that produces integers (boxed in NSNumbers).
  */
 FOX_EXPORT id<FOXGenerator> FOXNegativeInteger(void);
@@ -56,10 +60,20 @@ FOX_EXPORT id<FOXGenerator> FOXNegativeInteger(void);
  *  The size hint dictates the min & max integer values that can be generated,
  *  bounding to -1 as the maximum.
  *
+ *  @seealso FOXFamousStrictNegativeInteger
  *  @returns a generator that produces integers (boxed in NSNumbers).
  */
 FOX_EXPORT id<FOXGenerator> FOXStrictNegativeInteger(void);
 
+/*! Creates a generator that produces random NSIntegers (boxed as NSNumbers).
+ *  Does not include zero. Shrinks towards 1.
+ *
+ *  The size hint dictates the min & max integer values that can be generated.
+ *
+ *  @seealso FOXFamousNonZeroInteger
+ *  @returns a generator that produces integers (boxed in NSNumbers).
+ */
+FOX_EXPORT id<FOXGenerator> FOXNonZeroInteger(void);
 
 /*! Creates a generator that produces random floats (boxed as NSNumbers).
  *  Shrinks towards zero. Floats generated conform to IEEE standard.
@@ -87,3 +101,98 @@ FOX_EXPORT id<FOXGenerator> FOXDouble(void);
  *  @returns a generator that produces NSDecimalNumbers.
  */
 FOX_EXPORT id<FOXGenerator> FOXDecimalNumber(void);
+
+
+/*! Creates a generator that produces random NSIntegers with an increased
+ *  probability of picking INT_MAX and INT_MIN. Shrinks towards 0.
+ *
+ *  The size hint dictates the min & max values that can be generated. This is
+ *  ignored if INT_MAX or INT_MIN was probabilitically picked.
+ *
+ *  @warning Since this generator can produce large numbers, it is not
+ *           recommended to use this generator to produce collections.
+ *
+ *  @returns a generator that produces integers (boxed in NSNumbers).
+ */
+FOX_EXPORT id<FOXGenerator> FOXFamousInteger(void);
+
+/*! Creates a generator that produces random positive NSIntegers with an
+ *  increased probability of picking INT_MAX. Shrinks towards 0.
+ *
+ *  The size hint dictates the min & max values that can be generated. This is
+ *  ignored if INT_MAX was probabilitically picked.
+ *
+ *  @warning Since this generator can produce large numbers, it is not
+ *           recommended to use this generator to produce collections.
+ *
+ *  @returns a generator that produces integers (boxed in NSNumbers).
+ */
+FOX_EXPORT id<FOXGenerator> FOXFamousPositiveInteger(void);
+
+/*! Creates a generator that produces random negative NSIntegers with an
+ *  increased probability of picking INT_MIN. Shrinks towards 0.
+ *
+ *  The size hint dictates the min & max values that can be generated. This is
+ *  ignored if INT_MIN was probabilitically picked.
+ *
+ *  @warning Since this generator can produce large numbers, it is not
+ *           recommended to use this generator to produce collections.
+ *
+ *  @returns a generator that produces integers (boxed in NSNumbers).
+ */
+FOX_EXPORT id<FOXGenerator> FOXFamousNegativeInteger(void);
+
+/*! Creates a generator that produces random negative NSIntegers with an
+ *  increased probability of picking INT_MIN. Does not include zero.
+ *  Shrinks towards -1.
+ *
+ *  The size hint dictates the min & max values that can be generated. This is
+ *  ignored if INT_MIN was probabilitically picked.
+ *
+ *  @warning Since this generator can produce large numbers, it is not
+ *           recommended to use this generator to produce collections.
+ *
+ *  @returns a generator that produces integers (boxed in NSNumbers).
+ */
+FOX_EXPORT id<FOXGenerator> FOXFamousStrictNegativeInteger(void);
+
+/*! Creates a generator that produces random positive NSIntegers with an
+ *  increased probability of picking INT_MAX. Does not include zero.
+ *  Shrinks towards -1.
+ *
+ *  The size hint dictates the min & max values that can be generated. This is
+ *  ignored if INT_MAX was probabilitically picked.
+ *
+ *  @warning Since this generator can produce large numbers, it is not
+ *           recommended to use this generator to produce collections.
+ *
+ *  @returns a generator that produces integers (boxed in NSNumbers).
+ */
+FOX_EXPORT id<FOXGenerator> FOXFamousStrictPositiveInteger(void);
+
+/*! Creates a generator that produces random NSIntegers with an increased
+ *  probability of picking INT_MAX or INT_MIN. Does not include zero.
+ *  Shrinks towards 1.
+ *
+ *  The size hint dictates the min & max values that can be generated. This is
+ *  ignored if INT_MAX or INT_MIN was probabilitically picked.
+ *
+ *  @warning Since this generator can produce large numbers, it is not
+ *           recommended to use this generator to produce collections.
+ *
+ *  @returns a generator that produces integers (boxed in NSNumbers).
+ */
+FOX_EXPORT id<FOXGenerator> FOXFamousNonZeroInteger(void);
+
+/*! Creates a generator that produces random floats (boxed as NSNumbers) with
+ *  an increased probability of choosing extreme values (NAN, INFINITY,
+ *  -INFINITY, -0). Shrinks towards zero. Floats generated conform to
+ *  IEEE standard.
+ *
+ *  The size hint dictates the min & max values that can be generated.
+ *
+ *  @returns a generator that produces floats (boxed in NSNumbers).
+ */
+FOX_EXPORT id<FOXGenerator> FOXFamousFloat(void);
+FOX_EXPORT id<FOXGenerator> FOXFamousDouble(void);
+FOX_EXPORT id<FOXGenerator> FOXFamousDecimalNumber(void);

--- a/Fox/Public/Generators/FOXNumericGenerators.m
+++ b/Fox/Public/Generators/FOXNumericGenerators.m
@@ -4,6 +4,8 @@
 #import "FOXArrayGenerators.h"
 #import "FOXRoseTree.h"
 #import "FOXChooseGenerator.h"
+#import "FOXLimits.h"
+#import <float.h>
 
 FOX_EXPORT id<FOXGenerator> _FOXNaturalInteger(void) {
     return FOXMap(FOXInteger(), ^id(NSNumber *number) {
@@ -149,4 +151,75 @@ FOX_EXPORT id<FOXGenerator> FOXDecimalNumber(void) {
     });
 
     return FOXWithName(@"DecimalNumber", gen);
+}
+
+
+#pragma mark - Famous Generators
+
+FOX_EXPORT id<FOXGenerator> FOXFamousInteger(void) {
+    return FOXWithName(@"FamousInteger",
+                       FOXFrequency(@[@[@48, FOXInteger()],
+                                      @[@1, FOXReturn(@(INT_MAX))],
+                                      @[@1, FOXReturn(@(INT_MIN))]]));
+}
+
+FOX_EXPORT id<FOXGenerator> FOXFamousPositiveInteger(void) {
+    return FOXWithName(@"FamousPositiveInteger",
+                       FOXFrequency(@[@[@48, FOXPositiveInteger()],
+                                      @[@2, FOXReturn(@(INT_MAX))]]));
+}
+
+FOX_EXPORT id<FOXGenerator> FOXFamousNegativeInteger(void) {
+    return FOXWithName(@"FamousNegativeInteger",
+                       FOXFrequency(@[@[@48, FOXNegativeInteger()],
+                                      @[@2, FOXReturn(@(INT_MIN))]]));
+}
+
+FOX_EXPORT id<FOXGenerator> FOXFamousStrictNegativeInteger(void) {
+    return FOXWithName(@"FamousStrictNegativeInteger",
+                       FOXFrequency(@[@[@48, FOXStrictNegativeInteger()],
+                                      @[@2, FOXReturn(@(INT_MIN))]]));
+}
+
+FOX_EXPORT id<FOXGenerator> FOXFamousStrictPositiveInteger(void) {
+    return FOXWithName(@"FamousStrictPositiveInteger",
+                       FOXFrequency(@[@[@48, FOXStrictPositiveInteger()],
+                                      @[@2, FOXReturn(@(INT_MAX))]]));
+}
+
+FOX_EXPORT id<FOXGenerator> FOXFamousNonZeroInteger(void) {
+    return FOXWithName(@"FamousNonZeroInteger",
+                       FOXFrequency(@[@[@48, FOXNonZeroInteger()],
+                                      @[@1, FOXReturn(@(INT_MIN))],
+                                      @[@1, FOXReturn(@(INT_MAX))]]));
+}
+
+FOX_EXPORT id<FOXGenerator> FOXFamousFloat(void) {
+    return FOXWithName(@"FamousFloat",
+                       FOXFrequency(@[@[@44, FOXFloat()],
+                                      @[@1, FOXReturn(@(-0.f))],
+                                      @[@1, FOXReturn(@(FOXFloatMax()))],
+                                      @[@1, FOXReturn(@(-FOXFloatMax()))],
+                                      @[@1, FOXReturn(@(FOXFloatInfinity()))],
+                                      @[@1, FOXReturn(@(-FOXFloatInfinity()))],
+                                      @[@1, FOXReturn(@(FOXFloatQNaN()))]]));
+}
+
+FOX_EXPORT id<FOXGenerator> FOXFamousDouble(void) {
+    return FOXWithName(@"FamousDouble",
+                       FOXFrequency(@[@[@44, FOXDouble()],
+                                      @[@1, FOXReturn(@(-0.0))],
+                                      @[@1, FOXReturn(@(FOXDoubleMax()))],
+                                      @[@1, FOXReturn(@(-FOXDoubleMax()))],
+                                      @[@1, FOXReturn(@(FOXDoubleInfinity()))],
+                                      @[@1, FOXReturn(@(-FOXDoubleInfinity()))],
+                                      @[@1, FOXReturn(@(FOXDoubleQNaN()))]]));
+}
+
+FOX_EXPORT id<FOXGenerator> FOXFamousDecimalNumber(void) {
+    return FOXWithName(@"FamousDecimalNumber",
+                       FOXFrequency(@[@[@48, FOXDecimalNumber()],
+                                      @[@1, FOXReturn([NSDecimalNumber minimumDecimalNumber])],
+                                      @[@1, FOXReturn([NSDecimalNumber maximumDecimalNumber])],
+                                      @[@1, FOXReturn([NSDecimalNumber notANumber])]]));
 }

--- a/FoxSpecs/Public/Generators/FOXDecimalNumberSpec.mm
+++ b/FoxSpecs/Public/Generators/FOXDecimalNumberSpec.mm
@@ -74,4 +74,23 @@ describe(@"FOXDecimalNumber", ^{
     });
 });
 
+describe(@"FOXFamousDecimalNumber", ^{
+    it(@"should generate min, max, and NaN regularly", ^{
+        __block BOOL hasSeenNaN = NO;
+        __block BOOL hasSeenMin = NO;
+        __block BOOL hasSeenMax = NO;
+        FOXRunnerResult *result = [FOXSpecHelper resultForAll:FOXFamousDecimalNumber() then:^BOOL(NSDecimalNumber *value) {
+            hasSeenNaN = hasSeenNaN || [value isEqual:[NSDecimalNumber notANumber]];
+            hasSeenMax = hasSeenMax || [value isEqual:[NSDecimalNumber maximumDecimalNumber]];
+            hasSeenMin = hasSeenMax || [value isEqual:[NSDecimalNumber minimumDecimalNumber]];
+            return YES;
+        }];
+
+        hasSeenNaN should be_truthy;
+        hasSeenMax should be_truthy;
+        hasSeenMin should be_truthy;
+        result should be_truthy;
+    });
+});
+
 SPEC_END

--- a/FoxSpecs/Public/Generators/FOXDoubleSpec.mm
+++ b/FoxSpecs/Public/Generators/FOXDoubleSpec.mm
@@ -1,6 +1,7 @@
 #import <Cedar.h>
 #import "Fox.h"
 #import "FOXSpecHelper.h"
+#import <limits.h>
 
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
@@ -47,6 +48,39 @@ describe(@"FOXDouble", ^{
 
         result.succeeded should be_falsy;
         result.smallestFailingValue should be_greater_than_or_equal_to(@(-0.00000001));
+    });
+});
+
+
+describe(@"FOXFamousDouble", ^{
+    it(@"should generate min, max, and exceptional values regularly", ^{
+        __block BOOL hasSeenNaN = NO;
+        __block BOOL hasSeenNegZero = NO;
+        __block BOOL hasSeenPosInf = NO;
+        __block BOOL hasSeenNegInf = NO;
+        __block BOOL hasSeenMin = NO;
+        __block BOOL hasSeenMax = NO;
+        FOXRunnerResult *result = [FOXSpecHelper resultForAll:FOXFamousDouble() then:^BOOL(NSNumber *value) {
+            double val = [value doubleValue];
+            if (isnan(val)) {
+                hasSeenNaN = YES;
+                return YES;
+            }
+            hasSeenNegZero = hasSeenNegZero || [value isEqual:@(-0.f)];
+            hasSeenMax = hasSeenMax || [value isEqual:@(std::numeric_limits<double>::max())];
+            hasSeenMin = hasSeenMax || [value isEqual:@(-std::numeric_limits<double>::max())];
+            hasSeenPosInf = hasSeenPosInf || [value isEqual:@(std::numeric_limits<double>::infinity())];
+            hasSeenNegInf = hasSeenNegInf || [value isEqual:@(-std::numeric_limits<double>::infinity())];
+            return YES;
+        }];
+
+        hasSeenNaN should be_truthy;
+        hasSeenNegZero should be_truthy;
+        hasSeenMax should be_truthy;
+        hasSeenMin should be_truthy;
+        hasSeenPosInf should be_truthy;
+        hasSeenNegInf should be_truthy;
+        result should be_truthy;
     });
 });
 

--- a/FoxSpecs/Public/Generators/FOXFloatSpec.mm
+++ b/FoxSpecs/Public/Generators/FOXFloatSpec.mm
@@ -57,4 +57,36 @@ describe(@"FOXFloat", ^{
     });
 });
 
+describe(@"FOXFamousFloat", ^{
+    it(@"should generate min, max, and exceptional values regularly", ^{
+        __block BOOL hasSeenNaN = NO;
+        __block BOOL hasSeenNegZero = NO;
+        __block BOOL hasSeenPosInf = NO;
+        __block BOOL hasSeenNegInf = NO;
+        __block BOOL hasSeenMin = NO;
+        __block BOOL hasSeenMax = NO;
+        FOXRunnerResult *result = [FOXSpecHelper resultForAll:FOXFamousFloat() then:^BOOL(NSNumber *value) {
+            float val = [value floatValue];
+            if (isnan(val)) {
+                hasSeenNaN = YES;
+                return YES;
+            }
+            hasSeenNegZero = hasSeenNegZero || [value isEqual:@(-0.f)];
+            hasSeenMax = hasSeenMax || [value isEqual:@(FLT_MAX)];
+            hasSeenMin = hasSeenMax || [value isEqual:@(-FLT_MAX)];
+            hasSeenPosInf = hasSeenPosInf || [value isEqual:@(INFINITY)];
+            hasSeenNegInf = hasSeenNegInf || [value isEqual:@(-INFINITY)];
+            return YES;
+        }];
+
+        hasSeenNaN should be_truthy;
+        hasSeenNegZero should be_truthy;
+        hasSeenMax should be_truthy;
+        hasSeenMin should be_truthy;
+        hasSeenPosInf should be_truthy;
+        hasSeenNegInf should be_truthy;
+        result should be_truthy;
+    });
+});
+
 SPEC_END

--- a/FoxSpecs/Public/Generators/FOXIntegerSpec.mm
+++ b/FoxSpecs/Public/Generators/FOXIntegerSpec.mm
@@ -54,4 +54,20 @@ describe(@"FOXInteger", ^{
     });
 });
 
+describe(@"FOXFamousIntegers", ^{
+    it(@"should generate min and max integers", ^{
+        __block BOOL hasSeenIntMax = NO;
+        __block BOOL hasSeenIntMin = NO;
+        FOXRunnerResult *result = [FOXSpecHelper resultForAll:FOXFamousInteger() then:^BOOL(NSNumber *value) {
+            hasSeenIntMax = hasSeenIntMax || [value isEqual:@(INT_MAX)];
+            hasSeenIntMin = hasSeenIntMin || [value isEqual:@(INT_MIN)];
+            return YES;
+        }];
+
+        hasSeenIntMax should be_truthy;
+        hasSeenIntMin should be_truthy;
+        result should be_truthy;
+    });
+});
+
 SPEC_END

--- a/FoxSpecs/Public/Generators/FOXNegativeIntegerSpec.mm
+++ b/FoxSpecs/Public/Generators/FOXNegativeIntegerSpec.mm
@@ -57,4 +57,17 @@ describe(@"FOXNegativeInteger", ^{
     });
 });
 
+describe(@"FOXFamousNegativeInteger", ^{
+    it(@"should generate minimum negative signed integer", ^{
+        __block BOOL hasSeenIntMin = NO;
+        FOXRunnerResult *result = [FOXSpecHelper resultForAll:FOXFamousNegativeInteger() then:^BOOL(NSNumber *value) {
+            hasSeenIntMin = hasSeenIntMin || [value isEqual:@(INT_MIN)];
+            return YES;
+        }];
+
+        hasSeenIntMin should be_truthy;
+        result should be_truthy;
+    });
+});
+
 SPEC_END

--- a/FoxSpecs/Public/Generators/FOXPositiveIntegerSpec.mm
+++ b/FoxSpecs/Public/Generators/FOXPositiveIntegerSpec.mm
@@ -58,4 +58,17 @@ describe(@"FOXPositiveInteger", ^{
     });
 });
 
+describe(@"FOXFamousPositiveInteger", ^{
+    it(@"should generate maximum positive unsigned integer", ^{
+        __block BOOL hasSeenUIntMax = NO;
+        FOXRunnerResult *result = [FOXSpecHelper resultForAll:FOXFamousPositiveInteger() then:^BOOL(NSNumber *value) {
+            hasSeenUIntMax = hasSeenUIntMax || [value isEqual:@(INT_MAX)];
+            return YES;
+        }];
+
+        hasSeenUIntMax should be_truthy;
+        result should be_truthy;
+    });
+});
+
 SPEC_END

--- a/FoxSpecs/Public/Generators/FOXStrictNegativeIntegerSpec.mm
+++ b/FoxSpecs/Public/Generators/FOXStrictNegativeIntegerSpec.mm
@@ -38,13 +38,6 @@ describe(@"FOXFamousStrictNegativeInteger", ^{
             return [value integerValue] < 0;
         }));
     });
-
-    it(@"should shrink to -1", ^{
-        FOXRunnerResult *result = [FOXSpecHelper shrunkResultForAll:FOXFamousStrictNegativeInteger()];
-
-        result.succeeded should be_falsy;
-        result.smallestFailingValue should equal(@(-1));
-    });
 });
 
 SPEC_END

--- a/FoxSpecs/Public/Generators/FOXStrictNegativeIntegerSpec.mm
+++ b/FoxSpecs/Public/Generators/FOXStrictNegativeIntegerSpec.mm
@@ -1,0 +1,50 @@
+#import <Cedar.h>
+#import "Fox.h"
+#import "FOXSpecHelper.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(FOXStrictNegativeIntegerSpec)
+
+describe(@"FOXStrictNegativeInteger", ^{
+    it(@"should generate negative numbers, excluding zero", ^{
+        FOXAssert(FOXForAll(FOXStrictNegativeInteger(), ^BOOL(NSNumber *value) {
+            return [value integerValue] < 0;
+        }));
+    });
+
+    it(@"should shrink to -1", ^{
+        FOXRunnerResult *result = [FOXSpecHelper shrunkResultForAll:FOXStrictNegativeInteger()];
+
+        result.succeeded should be_falsy;
+        result.smallestFailingValue should equal(@(-1));
+    });
+});
+
+describe(@"FOXFamousStrictNegativeInteger", ^{
+    it(@"should generate INT_MIN more frequently", ^{
+        __block BOOL hasSeenIntMin = NO;
+        FOXAssert(FOXForAll(FOXFamousStrictNegativeInteger(), ^BOOL(NSNumber *value) {
+            hasSeenIntMin = hasSeenIntMin || [value integerValue] == INT_MIN;
+            return [value integerValue] < 0;
+        }));
+
+        hasSeenIntMin should be_truthy;
+    });
+
+    it(@"should generate negative numbers, excluding zero", ^{
+        FOXAssert(FOXForAll(FOXFamousStrictNegativeInteger(), ^BOOL(NSNumber *value) {
+            return [value integerValue] < 0;
+        }));
+    });
+
+    it(@"should shrink to -1", ^{
+        FOXRunnerResult *result = [FOXSpecHelper shrunkResultForAll:FOXFamousStrictNegativeInteger()];
+
+        result.succeeded should be_falsy;
+        result.smallestFailingValue should equal(@(-1));
+    });
+});
+
+SPEC_END

--- a/FoxSpecs/Public/Generators/FOXStrictPositiveIntegerSpec.mm
+++ b/FoxSpecs/Public/Generators/FOXStrictPositiveIntegerSpec.mm
@@ -1,0 +1,50 @@
+#import <Cedar.h>
+#import "Fox.h"
+#import "FOXSpecHelper.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(FOXStrictPositiveIntegerSpec)
+
+describe(@"FOXStrictPositiveInteger", ^{
+    it(@"should generate positive numbers, excluding zero", ^{
+        FOXAssert(FOXForAll(FOXStrictPositiveInteger(), ^BOOL(NSNumber *value) {
+            return [value integerValue] > 0;
+        }));
+    });
+
+    it(@"should shrink to 1", ^{
+        FOXRunnerResult *result = [FOXSpecHelper shrunkResultForAll:FOXStrictPositiveInteger()];
+
+        result.succeeded should be_falsy;
+        result.smallestFailingValue should equal(@1);
+    });
+});
+
+describe(@"FOXFamousStrictPositiveInteger", ^{
+    it(@"should generate INT_MAX more frequently", ^{
+        __block BOOL hasSeenIntMax = NO;
+        FOXAssert(FOXForAll(FOXFamousStrictPositiveInteger(), ^BOOL(NSNumber *value) {
+            hasSeenIntMax = hasSeenIntMax || [value integerValue] == INT_MAX;
+            return [value integerValue] > 0;
+        }));
+
+        hasSeenIntMax should be_truthy;
+    });
+
+    it(@"should generate positive numbers, excluding zero", ^{
+        FOXAssert(FOXForAll(FOXFamousStrictPositiveInteger(), ^BOOL(NSNumber *value) {
+            return [value integerValue] > 0;
+        }));
+    });
+
+    it(@"should shrink to 1", ^{
+        FOXRunnerResult *result = [FOXSpecHelper shrunkResultForAll:FOXFamousStrictPositiveInteger()];
+
+        result.succeeded should be_falsy;
+        result.smallestFailingValue should equal(@1);
+    });
+});
+
+SPEC_END

--- a/FoxSpecs/Public/Generators/FOXStrictPositiveIntegerSpec.mm
+++ b/FoxSpecs/Public/Generators/FOXStrictPositiveIntegerSpec.mm
@@ -38,13 +38,6 @@ describe(@"FOXFamousStrictPositiveInteger", ^{
             return [value integerValue] > 0;
         }));
     });
-
-    it(@"should shrink to 1", ^{
-        FOXRunnerResult *result = [FOXSpecHelper shrunkResultForAll:FOXFamousStrictPositiveInteger()];
-
-        result.succeeded should be_falsy;
-        result.smallestFailingValue should equal(@1);
-    });
 });
 
 SPEC_END

--- a/docs/source/generators_reference.rst
+++ b/docs/source/generators_reference.rst
@@ -20,40 +20,48 @@ generators shrink to zero:
  - Numerically zero (or as close as possible)
  - Empty collection (or at least shrunk items)
 
-.. c:function:: id<FOXGenerator> FOXInteger(void) // NSNumber
+.. c:function:: id<FOXGenerator> FOXInteger(void)
 
     Generates random integers boxed as a NSNumber. Shrinks to 0::
 
         FOXInteger()
         // example generations: 0, -1, 1
 
-.. c:function:: id<FOXGenerator> FOXPositiveInteger(void) // NSNumber
+.. c:function:: id<FOXGenerator> FOXPositiveInteger(void)
 
     Generates random positive integers boxed as a NSNumber. Shrinks to 0::
 
         FOXPositiveInteger()
         // example generations: 0, 1, 2
 
-.. c:function:: id<FOXGenerator> FOXNegativeInteger(void) // NSNumber
+.. c:function:: id<FOXGenerator> FOXNegativeInteger(void)
 
     Generates random negative integers boxed as a NSNumber. Shrinks to 0::
 
         FOXNegativeInteger()
         // example generations: 0, -1, -2
 
-.. c:function:: id<FOXGenerator> FOXStrictPositiveInteger(void) // NSNumber
+.. c:function:: id<FOXGenerator> FOXStrictPositiveInteger(void)
 
     Generates random positive integers boxed as a NSNumber. Shrinks to 1::
 
         FOXStrictPositiveInteger()
         // example generations: 1, 2, 3
 
-.. c:function:: id<FOXGenerator> FOXStrictNegativeInteger(void) // NSNumber
+.. c:function:: id<FOXGenerator> FOXStrictNegativeInteger(void)
 
     Generates random negative integers boxed as a NSNumber. Shrinks to -1::
 
         FOXStrictNegativeInteger()
         // example generations: -1, -2, -3
+
+.. c:function:: id<FOXGenerator> FOXNonZeroInteger(void)
+
+    Generates random negative integers boxed as a NSNumber. Shrinks to 1. Does
+    not emit 0::
+
+        FOXNonZeroInteger()
+        // example generations: -1, 2, -3
 
 .. c:function:: id<FOXGenerator> FOXChoose(NSNumber *miniumNumber, NSNumber *maximumNumber) // NSNumber
 
@@ -91,6 +99,112 @@ generators shrink to zero:
     unlikely.
 
 .. c:function:: id<FOXGenerator> FOXDecimalNumber(void) // NSDecimalNumber
+
+    Generates random decimal numbers. Shrinks towards zero by shrinking the
+    mantissa and exponent.
+
+    The generator **does not** generate NaNs::
+
+        FOXDecimalNumber()
+        // example generations: 0, -192000000000000000000000000000000000000000000, 790000000000000000000000000000000000000000000000000000000000000000000000000000
+
+.. c:function:: id<FOXGenerator> FOXFamousInteger(void)
+
+    Generates random integers boxed as a NSNumber. Shrinks to 0. Unlike
+    :c:func:`FOXInteger`, this generator increases the likelihood of generating
+    extreme values (INT_MAX, INT_MIN)::
+
+        FOXFamousInteger()
+        // example generations: 0, -1, 32767, -32767
+
+    It is not recommended to use this generator to produce collections.
+
+.. c:function:: id<FOXGenerator> FOXFamousPositiveInteger(void)
+
+    Generates random positive integers boxed as a NSNumber. Shrinks to 0.
+    Unlike :c:func:`FOXPositiveInteger`, this generator increases the likelihood
+    of generating extreme values (INT_MAX)::
+
+        FOXFamousPositiveInteger()
+        // example generations: 0, -1, 32767
+
+    It is not recommended to use this generator to produce collections.
+
+.. c:function:: id<FOXGenerator> FOXFamousNegativeInteger(void)
+
+    Generates random negative integers boxed as a NSNumber. Shrinks to 0.
+    Unlike :c:func:`FOXNegativeInteger`, this generator increases the likelihood
+    of generating extreme values (INT_MIN)::
+
+        FOXNegativeInteger()
+        // example generations: 0, -1, -2, -32767 
+
+    It is not recommended to use this generator to produce collections.
+
+.. c:function:: id<FOXGenerator> FOXFamousStrictPositiveInteger(void)
+
+    Generates random positive integers boxed as a NSNumber. Shrinks to 1.
+    Unlike :c:func:`FOXStrictPositiveInteger`, this generator increases the
+    likelihood of generating extreme values (INT_MAX)::
+
+        FOXFamousStrictPositiveInteger()
+        // example generations: 1, 5, 32767
+
+    It is not recommended to use this generator to produce collections.
+
+.. c:function:: id<FOXGenerator> FOXFamousStrictNegativeInteger(void)
+
+    Generates random negative integers boxed as a NSNumber. Shrinks to -1.
+    Unlike :c:func:`FOXStrictPositiveInteger`, this generator increases the
+    likelihood of generating extreme values (INT_MIN)::
+
+        FOXFamousStrictNegativeInteger()
+        // example generations: -1, -2, -32767
+
+    It is not recommended to use this generator to produce collections.
+
+.. c:function:: id<FOXGenerator> FOXFamousNonZeroInteger(void)
+
+    Generates random negative integers boxed as a NSNumber. Shrinks to 1. Does
+    not emit 0. Unlike :c:func:`FOXNonZeroInteger`, this generator increases the
+    likelihood of generating extreme values (INT_MAX, INT_MIN)::
+
+        FOXFamousNonZeroInteger()
+        // example generations: -4, 32767, -32767
+
+    It is not recommended to use this generator to produce collections.
+
+.. c:function:: id<FOXGenerator> FOXFamousFloat(void)
+
+    Generates random floating point numbers that conform to the IEEE 754
+    standard in a boxed NSNumber. Shrinks towards zero by shrinking the float's
+    exponent and mantissa. Unlike :c:func:`FOXFloat`, this generator increases
+    the likelihood of generating extreme values (FLT_MAX, -FLT_MAX, INFINITY,
+    -INFINITY, -0, NaN)::
+
+        FOXFamousFloat()
+        // example generations: 0, 3.436027e+10, -9.860766e-32, INFINITY
+
+    The generator **does not** generate negative zeros or negative infinities.
+    It is possible to generate positive infinity and NaNs, but is highly
+    unlikely.
+
+.. c:function:: id<FOXGenerator> FOXFamousDouble(void)
+
+    Generates random doubles that conform to the IEEE 754 standard in a boxed
+    NSNumber. Shrinks towards zero by shrinking the double's exponent and
+    mantissa. Unlike :c:func:`FOXDouble`, this generator increases the
+    likelihood of generating extreme values (max of double, -(max of double),
+    INFINITY, -INFINITY, -0, NaN)::  
+
+        FOXFamousDouble()
+        // example generations: 0, 6.983507489299851e-251, -INFINITY
+
+    The generator **does not** generate negative zeros or negative infinities.
+    It is possible to generate positive infinity and NaNs, but is highly
+    unlikely.
+
+.. c:function:: id<FOXGenerator> FOXDecimalNumber(void)
 
     Generates random decimal numbers. Shrinks towards zero by shrinking the
     mantissa and exponent.
@@ -473,7 +587,7 @@ generator adopts the same shrinking properties as the original generator.
 
     Dispatches to one of many generators by probability. Takes an array of
     tuples (2-sized array) - ``@[@[@probability_uint, generator]]``. Shrinking
-    follows whatever generator is returned.
+    follows whatever generator is returned::
 
         // equivalent to FOXOptional(FOXInteger())
         FOXFrequency(@[@[@1, FOXReturn(nil)],


### PR DESCRIPTION
Closes #26.

**Note** that shrinking for `FOXFrequency` is a different issue. (see #34)