### PR TITLE
Remove Fox-Swift.h from umbrella header

### DIFF
--- a/Fox/Public/Fox.h
+++ b/Fox/Public/Fox.h
@@ -43,5 +43,3 @@
 // DSL
 #import "FOXMacros.h"
 #import "FOXDSL.h"
-
-#import "Fox-Swift.h"


### PR DESCRIPTION
This was added in ee0dfae, but actually breaks the build. Removing it lets us
build successfully again.